### PR TITLE
we should include the timezone when dealing with time

### DIFF
--- a/readers/uptime.go
+++ b/readers/uptime.go
@@ -38,6 +38,7 @@ func (u *Uptime) Run() error {
 	u.Data["CurrentTimeUnixNano"] = currentTime.UnixNano()
 	u.Data["CurrentTime"] = currentTime.Format("15:04:05")
 	u.Data["Uptime"] = uptime.Format()
+        u.Data["TimeZone"] = currentTime.Format("MST")
 
 	return err
 }

--- a/readers/uptime_test.go
+++ b/readers/uptime_test.go
@@ -38,7 +38,7 @@ func TestNewUptimeToJson(t *testing.T) {
 		t.Errorf("jsonDataString shouldn't return error: %v", jsonDataString)
 	}
 
-	keysToTest := []string{"CurrentTimeUnixNano", "CurrentTime", "Uptime", "LoadAvg1m", "LoadAvg5m", "LoadAvg15m"}
+	keysToTest := []string{"CurrentTimeUnixNano", "CurrentTime", "Uptime", "LoadAvg1m", "LoadAvg5m", "LoadAvg15m", "TimeZone"}
 
 	for _, key := range keysToTest {
 		if !strings.Contains(jsonDataString, key) {


### PR DESCRIPTION
IMHO it's best to include timezone info when dealing with time, even if you're sure that all of your nodes are in the same timezone.

another work around is to ignore timezone info from the host and ENV and just force UTC. figured this was a nicer solution.

```
(master ✗)(~/git/go/src/github.com/resourced/resourced/readers)
pobrien@wordup.local:$ go test
PASS
ok      github.com/resourced/resourced/readers  0.071s
```
