### PR TITLE
Added 'dmidecode' reader support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,11 +12,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define "ubuntu" do |ubuntu|
     ubuntu.vm.box = "phusion/ubuntu-14.04-amd64"
     ubuntu.vm.provision :shell, path: "tests/data/provisioning/vagrant-ubuntu.sh"
+    ubuntu.vm.network :private_network, type: :static, ip: "192.168.50.240"
   end
 
   config.vm.define "centos" do |centos|
     centos.vm.box = "metcalfc/centos70-docker"
     centos.vm.provision :shell, path: "tests/data/provisioning/vagrant-centos.sh"
+    centos.vm.network :private_network, type: :static, ip: "192.168.50.241"
   end
 
   config.ssh.insert_key = 'true'

--- a/readers/base.go
+++ b/readers/base.go
@@ -105,6 +105,9 @@ func NewGoStruct(name string) (IReader, error) {
 	if name == "Uptime" {
 		structInstance = NewUptime()
 	}
+	if name == "DMI" {
+		structInstance = NewDMI()
+	}
 
 	if structInstance == nil {
 		return nil, errors.New("GoStruct is undefined.")

--- a/readers/dmi.go
+++ b/readers/dmi.go
@@ -1,0 +1,33 @@
+package readers
+
+import (
+	"encoding/json"
+
+	"github.com/dselans/dmidecode"
+)
+
+type DMI struct {
+	Data map[string]map[string]string
+}
+
+func NewDMI() *DMI {
+	d := &DMI{}
+	d.Data = make(map[string]map[string]string)
+	return d
+}
+
+func (d *DMI) Run() error {
+	dmi := dmidecode.New()
+
+	if err := dmi.Run(); err != nil {
+		return err
+	}
+
+	d.Data = dmi.Data
+
+	return nil
+}
+
+func (d *DMI) ToJson() ([]byte, error) {
+	return json.Marshal(d.Data)
+}

--- a/readers/dmi_test.go
+++ b/readers/dmi_test.go
@@ -1,0 +1,51 @@
+package readers
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestNewDMI(t *testing.T) {
+	d := NewDMI()
+	if d.Data == nil {
+		t.Error("Reader data should never be nil.")
+	}
+}
+
+func TestDMIRun(t *testing.T) {
+	// 'dmidecode' is not available on Darwin, run test only on Linux
+	if runtime.GOOS == "linux" {
+		d := NewDMI()
+		err := d.Run()
+		if err != nil {
+			t.Errorf("Fetching DMI data should always work. Error: %v", err)
+		}
+	}
+}
+
+func TestDMIToJson(t *testing.T) {
+	// 'dmidecode' is not available on Darwin, run test only on Linux
+	if runtime.GOOS == "linux" {
+		d := NewDMI()
+		err := d.Run()
+		if err != nil {
+			t.Errorf("Fetching DMI data should always work. Error: %v", err)
+		}
+
+		jsonData, err := d.ToJson()
+		if err != nil {
+			t.Errorf("Marshalling df data should always be successful. Error: %v", err)
+		}
+
+		jsonDataString := string(jsonData)
+
+		keysToTest := []string{"0x0001", "0x0002", "DMIName", "UUID"}
+
+		for _, key := range keysToTest {
+			if !strings.Contains(jsonDataString, key) {
+				t.Errorf("jsonDataString does not contain '%v' key. jsonDataString: %v", key, jsonDataString)
+			}
+		}
+	}
+}

--- a/tests/data/config-reader/gostruct-dmi.toml
+++ b/tests/data/config-reader/gostruct-dmi.toml
@@ -1,0 +1,3 @@
+GoStruct = "DMI"
+Path = "/dmi"
+Interval = "300s"


### PR DESCRIPTION
Easy peasy.

Tests verified to be working on Linux & Darwin.

Sample JSON output:

![sample json](https://cloud.githubusercontent.com/assets/1938759/6323959/45c52380-bae7-11e4-8432-75b625530c07.png)
