### PR TITLE
redis nil pointer deref bugfix

### DIFF
--- a/readers/redis/base.go
+++ b/readers/redis/base.go
@@ -21,8 +21,14 @@ func (r *Base) initConnection() error {
 		r.HostAndPort = ":6379"
 	}
 
+	// Does the connection exist?
 	if _, ok := connections[r.HostAndPort]; !ok {
-		connections[r.HostAndPort], err = redis.Dial("tcp", r.HostAndPort)
+		// Are we able to establish a connection to it?
+		if conn, redisErr := redis.Dial("tcp", r.HostAndPort); redisErr == nil {
+			connections[r.HostAndPort] = conn
+		} else {
+			err = redisErr
+		}
 	}
 
 	return err


### PR DESCRIPTION
This bug is not immediately obvious.

On first redis Run() loop - initConnection() would return an error, however it
would also inadvertantly add an (empty) entry in the connection map.
On second redis Run() loop - initConnection() would no longer return an error,
as it would see there is an entry in the connection map, although nil/empty.

There is still room for improvement here, as IF the redis service is shutdown
while resourced is running - it would likely run into another nil pointer
panic, as the connection would no longer work.

Best way is to probably disable connection pooling altogether and just create
a connection per run.
