### PR TITLE
Dselans/allowed hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ ResourceD accepts a few environment variables as configuration:
 
 * **RESOURCED_TAGS:** Comma separated tags. Default: ""
 
+* **RESOURCED_ALLOWED_NETWORKS:** Comma separated list of CIDR's that are allowed to use ResourceD's API endpoint. Default: ""
+
 
 ## Collecting Data
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -415,6 +415,11 @@ func (a *Agent) RunAllForever() {
 
 // Check if a given IP:PORT is part of an allowed CIDR
 func (a *Agent) IsAllowed(address string) bool {
+	// Allow all if we allowed networks is not set
+	if len(a.AllowedNetworks) == 0 {
+		return true
+	}
+
 	ip := libstring.GetIP(address)
 	if ip == nil {
 		return false

--- a/agent/agent_http.go
+++ b/agent/agent_http.go
@@ -10,6 +10,16 @@ import (
 	"strings"
 )
 
+// BaseHandler wraps all other handlers; returns 403 for clients that aren't authorized to connect.
+func (a *Agent) BaseHandler(h httprouter.Handle) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		if !a.IsAllowed(r.RemoteAddr) {
+			w.WriteHeader(403)
+			w.Write([]byte(fmt.Sprintf(`{"Error": "You are not authorized to connect."}`)))
+		}
+	}
+}
+
 // RootGetHandler returns function that handles all readers and writers.
 func (a *Agent) RootGetHandler() func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
@@ -259,21 +269,21 @@ func (a *Agent) MapWritersGetHandlers() map[string]func(w http.ResponseWriter, r
 func (a *Agent) HttpRouter() *httprouter.Router {
 	router := httprouter.New()
 
-	router.GET("/", a.RootGetHandler())
-	router.GET("/paths", a.PathsGetHandler())
+	router.GET("/", a.BaseHandler(a.RootGetHandler()))
+	router.GET("/paths", a.BaseHandler(a.PathsGetHandler()))
 
-	router.GET("/r", a.ReadersGetHandler())
-	router.GET("/r/paths", a.ReaderPathsGetHandler())
+	router.GET("/r", a.BaseHandler(a.ReadersGetHandler()))
+	router.GET("/r/paths", a.BaseHandler(a.ReaderPathsGetHandler()))
 
-	router.GET("/w", a.WritersGetHandler())
-	router.GET("/w/paths", a.WriterPathsGetHandler())
+	router.GET("/w", a.BaseHandler(a.WritersGetHandler()))
+	router.GET("/w/paths", a.BaseHandler(a.WriterPathsGetHandler()))
 
 	for readerPath, readerHandler := range a.MapReadersGetHandlers() {
-		router.GET(readerPath, readerHandler)
+		router.GET(readerPath, a.BaseHandler(readerHandler))
 	}
 
 	for writerPath, writerHandler := range a.MapWritersGetHandlers() {
-		router.GET(writerPath, writerHandler)
+		router.GET(writerPath, a.BaseHandler(writerHandler))
 	}
 
 	return router
@@ -294,7 +304,7 @@ func (a *Agent) ListenAndServe(addr string) error {
 }
 
 // ListenAndServe runs HTTPS server.
-func (a *Agent) ListenAndServeTLS(addr string, certFile string, keyFile string) error {
+func (a *Agent) ListenAndServeTLS(addr, certFile, keyFile string) error {
 	if addr == "" {
 		addr = ":55555"
 	}

--- a/agent/agent_http.go
+++ b/agent/agent_http.go
@@ -16,7 +16,12 @@ func (a *Agent) BaseHandler(h httprouter.Handle) httprouter.Handle {
 		if !a.IsAllowed(r.RemoteAddr) {
 			w.WriteHeader(403)
 			w.Write([]byte(fmt.Sprintf(`{"Error": "You are not authorized to connect."}`)))
+			return
 		}
+
+		// Forward request to given handle
+		h(w, r, ps)
+		return
 	}
 }
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -13,22 +13,16 @@ import (
 )
 
 func createAgentForAgentTest(t *testing.T) *Agent {
-	os.Setenv("RESOURCED_CONFIG_READER_DIR", "/go/src/github.com/resourced/resourced/tests/data/config-reader")
-	os.Setenv("RESOURCED_CONFIG_WRITER_DIR", "/go/src/github.com/resourced/resourced/tests/data/config-writer")
-	os.Setenv("RESOURCED_ALLOWED_NETWORKS", "0.0.0.0/0")
+	os.Setenv("RESOURCED_CONFIG_READER_DIR", "$GOPATH/src/github.com/resourced/resourced/tests/data/config-reader")
+	os.Setenv("RESOURCED_CONFIG_WRITER_DIR", "$GOPATH/src/github.com/resourced/resourced/tests/data/config-writer")
 
-	allowedNetworks := getNetworksForTest("0.0.0.0/0")
-
-	agent, err := NewAgent(allowedNetworks)
+	// Provide empty slice - allow all to connect
+	agent, err := NewAgent([]*net.IPNet{})
 	if err != nil {
 		t.Fatalf("Initializing agent should work. Error: %v", err)
 	}
-	return agent
-}
 
-func getNetworksForTest(cidr string) []*net.IPNet {
-	_, network, _ := net.ParseCIDR(cidr)
-	return []*net.IPNet{network}
+	return agent
 }
 
 func TestConstructor(t *testing.T) {
@@ -244,7 +238,8 @@ func TestCommonData(t *testing.T) {
 }
 
 func TestIsAllowed(t *testing.T) {
-	allowedNetworks := getNetworksForTest("127.0.0.1/8")
+	_, network, _ := net.ParseCIDR("127.0.0.1/8")
+	allowedNetworks := []*net.IPNet{network}
 
 	agent, err := NewAgent(allowedNetworks)
 	if err != nil {

--- a/libstring/libstring.go
+++ b/libstring/libstring.go
@@ -4,6 +4,7 @@ package libstring
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"net"
 	"os"
 	"os/user"
 	"strings"
@@ -59,4 +60,16 @@ func StringInSlice(beingSearched string, list []string) bool {
 		}
 	}
 	return false
+}
+
+// Split r.RemoteAddr, return an IP object (or nil if ParseIP fails)
+func GetIP(address string) net.IP {
+	// Try to parse it
+	splitAddress := strings.Split(address, ":")
+	if len(splitAddress) == 0 {
+		return nil
+	}
+
+	// Convert to IP object
+	return net.ParseIP(splitAddress[0])
 }

--- a/resourced.go
+++ b/resourced.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"github.com/Sirupsen/logrus"
-	resourced_agent "github.com/resourced/resourced/agent"
 	"os"
 	"runtime"
+
+	resourced_agent "github.com/resourced/resourced/agent"
+	resourced_util "github.com/resourced/resourced/util"
 )
 
 func init() {
@@ -24,7 +26,12 @@ func main() {
 		runtime.GOMAXPROCS(runtime.NumCPU())
 	}
 
-	agent, err := resourced_agent.NewAgent()
+	allowedNetworks, cidrErr := resourced_util.ParseCIDRs(os.Getenv("RESOURCED_ALLOWED_NETWORKS"))
+	if cidrErr != nil {
+		panic(cidrErr)
+	}
+
+	agent, err := resourced_agent.NewAgent(allowedNetworks)
 	if err != nil {
 		panic(err)
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,33 @@
+// Package contains miscelaneous utility functions
+package util
+
+import (
+	"net"
+	"strings"
+)
+
+// Parse a string with comma separated CIDR's; if given string is empty, return
+// a slice with a single 'default' 0.0.0.0 CIDR. Return slice of net.IPNet objs
+func ParseCIDRs(cidrs string) ([]*net.IPNet, error) {
+	if cidrs == "" {
+		_, defaultCIDR, _ := net.ParseCIDR("0.0.0.0/0")
+		return []*net.IPNet{defaultCIDR}, nil
+	}
+
+	// Get rid of spaces
+	cidrs = strings.Replace(cidrs, " ", "", -1)
+
+	// Convert cidr strings to net.IPNet objects
+	converted := []*net.IPNet{}
+
+	for _, value := range strings.Split(cidrs, ",") {
+		_, newCIDR, err := net.ParseCIDR(value)
+		if err != nil {
+			return converted, err
+		}
+
+		converted = append(converted, newCIDR)
+	}
+
+	return converted, nil
+}

--- a/util/util.go
+++ b/util/util.go
@@ -6,12 +6,11 @@ import (
 	"strings"
 )
 
-// Parse a string with comma separated CIDR's; if given string is empty, return
-// a slice with a single 'default' 0.0.0.0 CIDR. Return slice of net.IPNet objs
+// Parse a string with comma separated CIDR's; return slice of net.IPNet objs;
+// if given string is empty, return an empty slice of net.IPNet objs instead.
 func ParseCIDRs(cidrs string) ([]*net.IPNet, error) {
 	if cidrs == "" {
-		_, defaultCIDR, _ := net.ParseCIDR("0.0.0.0/0")
-		return []*net.IPNet{defaultCIDR}, nil
+		return []*net.IPNet{}, nil
 	}
 
 	// Get rid of spaces

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,1 @@
+package util

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,1 +1,33 @@
 package util
+
+import (
+	"testing"
+)
+
+func TestParseCIDRs(t *testing.T) {
+	goodCIDRs := []string{"127.0.0.1/8", "127.0.0.1/8, 0.0.0.0/0", "  0.0.0.0/0,  127.0.0.1/24 "}
+	badCIDRs := []string{"127.0.0.1", "127.0.0.1/99", "127.0.0.2/8 127.0.0.1/24"}
+
+	for _, goodCIDR := range goodCIDRs {
+		_, err := ParseCIDRs(goodCIDR)
+		if err != nil {
+			t.Errorf("'%v' should pass as a good CIDR value. Err: %s", goodCIDR, err)
+		}
+	}
+
+	for _, badCIDR := range badCIDRs {
+		_, err := ParseCIDRs(badCIDR)
+		if err == nil {
+			t.Errorf("'%v' should NOT pass as proper CIDR value. Err: %s", badCIDR, err)
+		}
+	}
+
+	cidrs, err := ParseCIDRs(goodCIDRs[0])
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if len(cidrs) != 1 {
+		t.Errorf("'cidrs' should have 1 element, but has %v", len(cidrs))
+	}
+}


### PR DESCRIPTION
Added the ability to configure what CIDR's are allowed to read from the API.

Added a BaseHandler that wraps all other handlers.

PS. agent_writer_test.go causes tests to hang; had to comment it out fully to get anywhere.
PPS. How does "$GOPATH" get extrapolated from something like this:

```
config.GoStructFields["JsonProcessor"] = "$GOPATH/src/github.com/resourced/resourced/tests/data/script-writer/json-flattener.py"
```

Shouldn't the `GOPATH` be os.Getenv()'d in each test? I had to change each one manually to make the tests pass (maybe I'm missing something obvious).
